### PR TITLE
Use argparse to add --output flag to plotting script

### DIFF
--- a/episodes/06-expansion.md
+++ b/episodes/06-expansion.md
@@ -119,7 +119,7 @@ curl -O https://ocaisa.github.io/hpc-workflows/files/plot_terse_amdahl_results.p
 The script `plot_terse_amdahl_results.py` needs a command line that looks like:
 
 ```bash
-python plot_terse_amdahl_results.py <output jpeg filename> <1st input file> <2nd input file> ...
+python plot_terse_amdahl_results.py --output <output image filename> <1st input file> <2nd input file> ...
 ```
 
 Let's introduce that into our `generate_run_files` rule:
@@ -129,7 +129,7 @@ rule generate_run_files:
     output: "p_{parallel_proportion}_runs.txt"
     input:  expand("p_{{parallel_proportion}}/runs/amdahl_run_{count}.json", count=NTASK_SIZES)
     shell:
-        "python plot_terse_amdahl_results.py {output} {input}"
+        "python plot_terse_amdahl_results.py --output {output} {input}"
 ```
 
 ::: challenge
@@ -146,7 +146,7 @@ rule generate_run_files:
     envmodules:
       "matplotlib"
     shell:
-        "python plot_terse_amdahl_results.py {output} {input}"
+        "python plot_terse_amdahl_results.py --output {output} {input}"
 ```
 
 ::::::
@@ -188,6 +188,7 @@ snakemake --profile cluster_profile/ p_0.8_scalability.jpg
 :::
 
 ::: challenge
+
 ## Bonus round
 
 Create a final rule that can be called directly and generates a scaling plot for

--- a/episodes/files/plot_terse_amdahl_results.py
+++ b/episodes/files/plot_terse_amdahl_results.py
@@ -1,13 +1,22 @@
-import sys
+#!/usr/bin/env python3
+import argparse
 import json
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
-def process_files(file_list, output="plot.jpg"):
+matplotlib.use('AGG')
+
+description = """
+Plot results of an Amdahl scaling study,
+assuming the '--terse' output flag was used.
+"""
+
+def process_files(output, file_list):
     value_tuples=[]
     for filename in file_list:
       # Open the JSON file and load data
-      with open(filename, 'r') as file:
+      with open(str(filename), 'r') as file:
         data = json.load(file)
       value_tuples.append((data['nproc'], data['execution_time']))
 
@@ -22,9 +31,10 @@ def process_files(file_list, output="plot.jpg"):
 
     # Adding the y=1/x line
     x_line = np.linspace(1, max(x), 100)  # Create x values for the line
-    y_line = (y[0]/x[0]) / x_line  # Calculate corresponding (scaled) y values
+    y_line = (y[0] / x[0]) / x_line       # Calculate corresponding (scaled) y values
 
-    plt.plot(x_line, y_line, linestyle='--', color='red', label='Perfect scaling')
+    plt.plot(x_line, y_line, linestyle='--',
+             color='red', label='Perfect scaling')
 
     # Adding title and labels
     plt.title("Scaling plot")
@@ -34,16 +44,28 @@ def process_files(file_list, output="plot.jpg"):
     # Show the legend
     plt.legend()
 
-    # Save the plot to a JPEG file
-    plt.savefig(output, format='jpeg')
+    # Save the plot to the specified file
+    plt.savefig(output, dpi=400, bbox_inches="tight")
 
 if __name__ == "__main__":
-    # The first command-line argument is the script name itself, so we skip it
-    output = sys.argv[1]
-    filenames = sys.argv[2:]
+    parser = argparse.ArgumentParser(
+        description=description,
+        epilog="Brought to you by HPC Carpentry"
+    )
 
-    if filenames:
-        process_files(filenames, output=output)
-    else:
-        print("No files provided.")
+    parser.add_argument(
+        "--output",
+        default="scaling-study.png",
+        help="Image file to write (PNG or JPG)",
+        required=True
+    )
 
+    parser.add_argument(
+        "inputs",
+        help="Amdahl terse output files (JSON)",
+        nargs="+"
+    )
+
+    args = parser.parse_args()
+
+    process_files(args.output, args.inputs)

--- a/episodes/files/plot_terse_amdahl_results.py
+++ b/episodes/files/plot_terse_amdahl_results.py
@@ -65,7 +65,6 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--output",
-        default="scaling-study.png",
         help="Image file to write (PNG or JPG)",
         required=True
     )

--- a/episodes/files/plot_terse_amdahl_results.py
+++ b/episodes/files/plot_terse_amdahl_results.py
@@ -16,9 +16,19 @@ def process_files(output, file_list):
     value_tuples=[]
     for filename in file_list:
       # Open the JSON file and load data
-      with open(str(filename), 'r') as file:
-        data = json.load(file)
-      value_tuples.append((data['nproc'], data['execution_time']))
+      try:
+          with open(filename, 'r') as file:
+              data = json.load(file)
+          value_tuples.append((data['nproc'], data['execution_time']))
+      except FileNotFoundError:
+          print(f"Error: File {filename} not found.")
+          return
+      except json.JSONDecodeError:
+          print(f"Error: File {filename} is not a valid JSON.")
+          return
+      except KeyError:
+          print(f"Error: Missing required data in file {filename}.")
+          return
 
     # Sort the tuples
     sorted_list = sorted(value_tuples)


### PR DESCRIPTION
This PR (programmed by an alleged human) uses the `argparse` module to document the `plot_terse_amdahl_results.py` program, adding a `--output` flag (required), revoking the requirement of JPEG output (matplotlib will guess the appropriate format from the filename, and error out if unknown), and updates the lesson content to use the new flag.

Supersedes #17. Closes #17.